### PR TITLE
Disable ifupdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This file will be uploaded and applied to managed node.
 `netplan_ifupdown_disable` -- disable "ifupdown" network management system
 (default value: `no`).
 
+`netplan_ifupdown_reset_interfaces` -- reset `/etc/network/interfaces`
+(default value: `no`). Leave loopback interface only. A backup of original
+content is preserved.
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This file will be uploaded and applied to managed node.
 `netplan_resolved_enable` -- enable systemd-resolved service
 (default value: `no`).
 
+`netplan_ifupdown_disable` -- disable "ifupdown" network management system
+(default value: `no`).
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 netplan_cloudinit_disable: no
+netplan_ifupdown_disable: no
 netplan_networkd_enable: no
 netplan_resolved_enable: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 netplan_cloudinit_disable: no
 netplan_ifupdown_disable: no
+netplan_ifupdown_reset_interfaces: no
 netplan_networkd_enable: no
 netplan_resolved_enable: no

--- a/files/interfaces
+++ b/files/interfaces
@@ -1,0 +1,2 @@
+allow-auto lo
+iface lo inet loopback

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,7 @@
       ansible.builtin.apt:
         name:
           - iputils-ping
+          - ifupdown
           # Fixes Netplan failure. The following exception is thrown on
           # "netplan apply" command execution:
           # FileNotFoundError: [Errno 2] No such file or directory: 'udevadm'

--- a/molecule/default/host_vars/host1.yml
+++ b/molecule/default/host_vars/host1.yml
@@ -3,3 +3,5 @@ ansible_python_interpreter: python3
 
 netplan_config: netplan_config/host1.yml
 netplan_networkd_enable: yes
+netplan_ifupdown_disable: yes
+netplan_ifupdown_reset_interfaces: yes

--- a/molecule/default/host_vars/host2.yml
+++ b/molecule/default/host_vars/host2.yml
@@ -3,3 +3,5 @@ ansible_python_interpreter: python3
 
 netplan_config: netplan_config/host2.yml
 netplan_networkd_enable: yes
+netplan_ifupdown_disable: yes
+netplan_ifupdown_reset_interfaces: yes

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,3 +6,12 @@
     - name: ping host2
       ansible.builtin.command: ping -c 3 192.168.0.102
       changed_when: no
+
+    - name: get path to backups of original /etc/network/interfaces
+      ansible.builtin.command: find /etc/network -name 'interfaces.*~'
+      changed_when: no
+      register: _result
+
+    - name: check that backup exists
+      ansible.builtin.assert:
+        that: _result.stdout_lines|length == 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,13 @@
     state: absent
   when: netplan_cloudinit_disable
 
+- name: disable ifupdown
+  ansible.builtin.systemd:
+    name: networking.service
+    state: stopped
+    enabled: no
+  when: netplan_ifupdown_disable
+
 - name: enable systemd-networkd
   ansible.builtin.systemd:
     name: systemd-networkd.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,14 @@
     enabled: no
   when: netplan_ifupdown_disable
 
+- name: reset /etc/network/interfaces
+  ansible.builtin.copy:
+    src: interfaces
+    dest: /etc/network/interfaces
+    mode: u=rw,g=r,o=r
+    backup: yes
+  when: netplan_ifupdown_reset_interfaces
+
 - name: enable systemd-networkd
   ansible.builtin.systemd:
     name: systemd-networkd.service


### PR DESCRIPTION
Add `netplan_ifupdown_disable` variable that disables "ifupdown" network management by stopping and unloading `networking.service`.

Add `netplan_ifupdown_reset_interfaces` variable that resets `/etc/network/interfaces` content to the following (backup of the original content is preserved):

```
allow-auto lo
iface lo inet loopback
```

Closes #1