### PR TITLE
Add example of "netplan_ifupdown_*" usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Example Playbook
         netplan_cloudinit_disable: yes
         netplan_networkd_enable: yes
         netplan_resolved_enable: yes
+        netplan_ifupdown_disable: yes
+        netplan_ifupdown_reset_interfaces: yes
 ```
 
 License


### PR DESCRIPTION
Added the following variables to example playbook:

- `netplan_ifupdown_disable`
- `netplan_ifupdown_reset_interfaces`