### PR TITLE
Unload "networking.service" without stopping

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,6 @@
 - name: disable ifupdown
   ansible.builtin.systemd:
     name: networking.service
-    state: stopped
     enabled: no
   when: netplan_ifupdown_disable
 


### PR DESCRIPTION
Stopping "networking.service" resets network configuration. Unload "networking.service" without stopping.

Closes #6