### PR TITLE
Remove unused filter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Set Netplan configuration
   ansible.builtin.copy:
-    src: "{{ netplan_config | mandatory }}"
+    src: "{{ netplan_config }}"
     dest: /etc/netplan/config.yaml
     mode: u=rw,g=r,o=r
   notify:


### PR DESCRIPTION
The `mandatory` filter is not required with default Ansible configuration. See ["Defining mandatory values"][1]:

> By default, Ansible fails if a variable in your playbook or command is
> undefined.

[1]: https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#defining-mandatory-values