### PR TITLE
Fix "the role 'netplan' was not found" error

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,4 +17,4 @@
 
     - name: Configure Netplan
       ansible.builtin.import_role:
-        name: netplan
+        name: yabusygin.netplan


### PR DESCRIPTION
Fix Ansible Lint `syntax-check[specific]` error (the role 'netplan' was not found).