### PR TITLE
Fix example playbook formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Example Playbook
 
 ```yaml
 ---
-- name: example playbook
+- name: Example playbook
   hosts: server
   tasks:
-    - name: configure networking
+    - name: Configure networking
       ansible.builtin.import_role:
         name: netplan
       vars:


### PR DESCRIPTION
The example playbook formatting now meets the Ansible Lint requirements (all names should start with an uppercase letter).